### PR TITLE
Bump timeouts

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 0.4.0
+version: 0.4.1
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -40,14 +40,14 @@ memoryLimits: "1024Mi"
 cpuLimits: "2500m"
 
 readinessPath: "/health"
-readinessDelay: 30
+readinessDelay: 60
 readinessTimeout: 3
 readinessPeriod: 15
 livenessPath: "/health"
-livenessDelay: 30
+livenessDelay: 60
 livenessTimeout: 3
 livenessPeriod: 15
-livenessFailureThreshold: 3
+livenessFailureThreshold: 5
 
 postgresql:
   postgresqlUsername: hmcts


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPE-910


### Change description ###
Bump liveness and readiness timeouts, seeing 90 second start time in elasticsearch setup after the full stack has been deployed if one container needs restarting


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
