### PR TITLE
Add CCD_DEF_FILENAME env var to importer manifest

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 0.5.3
+version: 0.5.4
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/templates/definition-importer.yaml
+++ b/ccd/templates/definition-importer.yaml
@@ -61,6 +61,8 @@ spec:
           env:
           - name: CCD_DEF_URLS
             value: {{ join "," .Values.importer.definitions | quote }}
+          - name: CCD_DEF_FILENAME
+            value: {{ .Values.importer.definitionFilename | quote }}
           - name: WAIT_HOSTS
             value: {{ .Values.importer.waitHosts | quote }}
           - name: WAIT_HOSTS_TIMEOUT


### PR DESCRIPTION

### Change description ###

Adding environment variable so can pass local filename to use for import. Useful when using baked in definitions, e.g. https://github.com/hmcts/cmc-ccd-definitions

https://github.com/hmcts/ccd-docker-definition-importer/blob/master/scripts/upload-definition.sh

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
