### PR TITLE
Add ccd-web-admin ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ ccd:
   caseManagementWeb:
    # enabled: true # if you need access to the web ui then enable this, otherwise it won't be deployed
 
-   printApi:
+  adminWeb:
+   # enabled: true # if you need access to the admin web ui then enable this, otherwise it won't be deployed
+
+  printApi:
     # enabled: true # if you need access to the case print service then enable this
     s2sKey: ${PRINT_S2S_KEY}
     probateTemplateUrl: http://${SERVICE_NAME}-probate-app
@@ -108,6 +111,12 @@ If you need to change from the defaults consider sending a PR to the chart inste
 | `caseManagementWeb.enabled`          | If case management web (and api gateway) will be deployed | `false`
 | `caseManagementWeb.image`          | Case management web image version | `hmcts.azurecr.io/hmcts/ccd-case-management-web:latest`|
 | `caseManagementWeb.applicationPort`                    | Port case management web runs on | `3451` |
+| `adminWeb.enabled`          | If admin web will be deployed | `false`
+| `adminWeb.image`          | Admin web image version | `hmcts.azurecr.io/hmcts/ccd-admin-web:latest`|
+| `adminWeb.applicationPort`                    | Port admin web runs on | `3100` |
+| `adminWeb.s2sKey`                    | S2S key | `nil` (required must be set by user) |
+| `adminWeb.idamClientSecret`                    | Idam OAuth client secret key | `nil` (required must be set by user) |
+| `adminWeb.environment`                    | Environment | `nil` see https://github.com/hmcts/ccd-admin-web |
 | `apiGateway.image`          | Api gateway's image version | `hmcts.azurecr.io/hmcts/ccd-api-gateway-web:latest`|
 | `apiGateway.applicationPort`                    | Port definition store api runs on | `3453` |
 | `apiGateway.s2sKey`                    | S2S key | `nil` (required must be set by user) |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ ccd:
 
   adminWeb:
    # enabled: true # if you need access to the admin web ui then enable this, otherwise it won't be deployed
+   # s2sKey: ${ADMIN_WEB_S2S_KEY}
+   # idamClientSecret: ${ADMIN_WEB_IDAM_SECRET}
 
   printApi:
     # enabled: true # if you need access to the case print service then enable this

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ If you need to change from the defaults consider sending a PR to the chart inste
 | `adminWeb.applicationPort`                    | Port admin web runs on | `3100` |
 | `adminWeb.s2sKey`                    | S2S key | `nil` (required must be set by user) |
 | `adminWeb.idamClientSecret`                    | Idam OAuth client secret key | `nil` (required must be set by user) |
-| `adminWeb.environment`                    | Environment | `nil` see https://github.com/hmcts/ccd-admin-web |
 | `apiGateway.image`          | Api gateway's image version | `hmcts.azurecr.io/hmcts/ccd-api-gateway-web:latest`|
 | `apiGateway.applicationPort`                    | Port definition store api runs on | `3453` |
 | `apiGateway.s2sKey`                    | S2S key | `nil` (required must be set by user) |

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ ccd:
 
   adminWeb:
    # enabled: true # if you need access to the admin web ui then enable this, otherwise it won't be deployed
-   # s2sKey: ${ADMIN_WEB_S2S_KEY}
-   # idamClientSecret: ${ADMIN_WEB_IDAM_SECRET}
+   s2sKey: ${ADMIN_WEB_S2S_KEY}
+   idamClientSecret: ${ADMIN_WEB_IDAM_SECRET}
 
   printApi:
     # enabled: true # if you need access to the case print service then enable this

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 0.5.4
+version: 0.5.5
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 0.5.5
+version: 0.6.0
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/templates/admin-web-service.yaml
+++ b/ccd/templates/admin-web-service.yaml
@@ -1,0 +1,20 @@
+---
+{{- if .Values.adminWeb.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-admin-web
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-admin-web
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: {{ .Values.adminWeb.applicationPort }}
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}-admin-web
+{{- end }}

--- a/ccd/templates/admin-web.yaml
+++ b/ccd/templates/admin-web.yaml
@@ -25,7 +25,7 @@ spec:
         - name: IDAM_OAUTH2_CLIENT_ID
           value: ccd_admin
         - name: HPKP_MAX_AGE
-          value: 2592000
+          value: '2592000'
         - name: HPKP_SHA256S
           value: Set-proper-SHA256s
         - name: IDAM_SERVICE_NAME
@@ -39,9 +39,9 @@ spec:
         - name: TS_BASE_URL
           value: ./src/main
         - name: USE_CSRF_PROTECTION
-          value: true
+          value: 'true'
         - name: UV_THREADPOOL_SIZE
-          value: 64
+          value: '64'
         - name: ADMIN_ALL_USER_ROLES_URL
           value: https://definition-store-api-{{ .Values.ingressHost }}/api/user-roles
         - name: ADMINWEB_AUTHORIZATION_URL

--- a/ccd/templates/admin-web.yaml
+++ b/ccd/templates/admin-web.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.adminWeb.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-admin-web
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-admin-web
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}-admin-web
+    app.kubernetes.io/instance: {{ .Release.Name }}-admin-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-admin-web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-admin-web
+    spec:
+      containers:
+      - image: {{ .Values.adminWeb.image }}
+        name: {{ .Release.Name }}-admin-web
+        env:
+        - name: ADMIN_ALL_USER_ROLES_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/user-roles
+        - name: ADMINWEB_AUTHORIZATION_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/idam/adminweb/authorization
+        - name: ADMINWEB_CREATE_DEFINITION_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/draft
+        - name: ADMINWEB_DEFINITIONS_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/drafts
+        - name: ADMINWEB_IMPORT_AUDITS_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/import-audits
+        - name: ADMINWEB_IMPORT_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/import
+        - name: ADMINWEB_JURISDICTIONS_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/data/jurisdictions
+        - name: ADMINWEB_UPDATE_DEFINITION_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/draft/save
+        - name: ADMINWEB_USER_ROLE_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/user-role
+        - name: ADMINWEB_WHOAMI_URL
+          value: https://definition-store-api-{{ .Values.ingressHost }}/api/idam/profile
+        - name: ADMINWEB_SAVE_USER_PROFILE_URL
+          value: https://user-profile-api-{{ .Values.ingressHost }}/users/save
+        - name: ADMINWEB_USER_PROFILE_URL
+          value: https://user-profile-api-{{ .Values.ingressHost }}/users
+        - name: ADMINWEB_LOGIN_URL
+          value: {{ .Values.idamWebUrl }}/login
+        - name: IDAM_LOGOUT_URL
+          value: {{ .Values.idamWebUrl }}/login/logout
+        - name: IDAM_BASE_URL
+          value: {{ .Values.idamApiUrl }}
+        - name: IDAM_OAUTH2_TOKEN_ENDPOINT
+          value: {{ .Values.idamApiUrl }}/oauth2/token
+        - name: IDAM_S2S_URL
+          value: {{ .Values.s2sUrl }}
+        - name: IDAM_ADMIN_WEB_SERVICE_KEY
+          value: {{ required "`adminWeb.s2sKey` must be set in your values.yaml file" .Values.adminWeb.s2sKey }}
+        - name: IDAM_OAUTH2_AW_CLIENT_SECRET
+          value: {{ required "`adminWeb.idamClientSecret` must be set in your values.yaml file" .Values.adminWeb.idamClientSecret }}
+        {{- if .Values.adminWeb.environment }}
+          {{- range $key, $val := .Values.adminWeb.environment }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+          {{- end}}
+        {{- end }}
+        resources:
+          requests:
+            memory: {{ .Values.memoryRequests }}
+            cpu: {{ .Values.cpuRequests }}
+          limits:
+            memory: {{ .Values.memoryLimits }}
+            cpu: {{ .Values.cpuLimits }}
+        ports:
+        - containerPort: {{ .Values.adminWeb.applicationPort }}
+          name: http
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.livenessPath }}
+            port: {{ .Values.adminWeb.applicationPort }}
+          initialDelaySeconds: {{ .Values.livenessDelay }}
+          timeoutSeconds: {{ .Values.livenessTimeout }}
+          periodSeconds: {{ .Values.livenessPeriod }}
+          failureThreshold: {{ .Values.livenessFailureThreshold }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.readinessPath }}
+            port: {{ .Values.adminWeb.applicationPort }}
+          initialDelaySeconds: {{ .Values.readinessDelay }}
+          timeoutSeconds: {{ .Values.readinessTimeout }}
+          periodSeconds: {{ .Values.readinessPeriod }}
+        imagePullPolicy: IfNotPresent
+{{- end }}

--- a/ccd/templates/admin-web.yaml
+++ b/ccd/templates/admin-web.yaml
@@ -22,6 +22,26 @@ spec:
       - image: {{ .Values.adminWeb.image }}
         name: {{ .Release.Name }}-admin-web
         env:
+        - name: IDAM_OAUTH2_CLIENT_ID
+          value: ccd_admin
+        - name: HPKP_MAX_AGE
+          value: 2592000
+        - name: HPKP_SHA256S
+          value: Set-proper-SHA256s
+        - name: IDAM_SERVICE_NAME
+          value: ccd_admin
+        - name: NODE_CONFIG_DIR
+          value: ./config
+        - name: NODE_ENV
+          value: production
+        - name: SECURITY_REFERRER_POLICY
+          value: origin
+        - name: TS_BASE_URL
+          value: ./src/main
+        - name: USE_CSRF_PROTECTION
+          value: true
+        - name: UV_THREADPOOL_SIZE
+          value: 64
         - name: ADMIN_ALL_USER_ROLES_URL
           value: https://definition-store-api-{{ .Values.ingressHost }}/api/user-roles
         - name: ADMINWEB_AUTHORIZATION_URL

--- a/ccd/templates/dns.yaml
+++ b/ccd/templates/dns.yaml
@@ -33,6 +33,9 @@ spec:
           command: [ "/bin/sh" ]
           args:
             - /container.init/ccd-dns
+            {{- if .Values.adminWeb.enabled }}
+            - admin-web-{{ .Release.Name }}
+            {{- end }}          
             {{- if .Values.caseManagementWeb.enabled }}
             - case-management-web-{{ .Release.Name }}
             - gateway-{{ .Release.Name }}

--- a/ccd/templates/ingress.yaml
+++ b/ccd/templates/ingress.yaml
@@ -35,6 +35,15 @@ spec:
           serviceName: {{ .Release.Name }}-api-gateway
           servicePort: 80
   {{- end }}
+  {{- if .Values.adminWeb.enabled }}
+  - host: admin-web-{{ .Values.ingressHost }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-admin-web
+          servicePort: 80
+  {{- end }}
   {{- if .Values.printApi.enabled }}
   - host: print-api-{{ .Values.ingressHost }}
     http:

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -18,6 +18,11 @@ caseManagementWeb:
   image: hmcts.azurecr.io/hmcts/ccd-case-management-web:latest
   applicationPort: 3451
 
+adminWeb:
+  enabled: false
+  image: hmcts.azurecr.io/hmcts/ccd-admin-web:latest
+  applicationPort: 3100
+
 apiGateway:
   image: hmcts.azurecr.io/hmcts/ccd-api-gateway-web:latest
   applicationPort: 3453


### PR DESCRIPTION
### Change description ###

Add admin ui to ccd chart stack (https://github.com/hmcts/ccd-admin-web). Our BA can then experiment with loading definitions in PR isolation before commiting to any higher envs like dev/aat/prod.

Tested locally: you can see helm release `cmc-ccd` and pods: `kubectl get po -n money-claims | grep cmc-ccd`

Sample yaml to add:

```
  adminWeb:
   enabled: true
   s2sKey: ****
   idamClientSecret: ****
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
