### PR TITLE
Add user-profile importer resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,44 @@ ccd:
 
 ```
 
+## Importers
+
+In addition to the core services you can include some helper pods to import definitions and user profiles:
+
+- defintions: https://github.com/hmcts/ccd-docker-definition-importer
+- user profiles: https://github.com/hmcts/ccd-docker-user-profile-importer
+
+values.template.yaml
+```yaml
+ccd:
+  # above config for core services
+
+  importer:
+    userprofile:
+      enabled: true
+      users:
+        - civilmoneyclaims+ccd@gmail.com|CMC|MoneyClaimCase|Open
+      jurisdictions:
+        - CMC
+      waitHosts: ${SERVICE_NAME}-user-profile-api
+      userProfileDatabaseHost: ${SERVICE_NAME}-claim-store-postgres
+      userProfileDatabasePort: 5432
+      userProfileDatabaseUser: hmcts
+      userProfileDatabasePassword: hmcts
+      userProfileDatabaseName: user-profile
+    definition:
+      enabled: true
+      definitions:
+        - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test.template.xlsx
+      userRoles:
+        - citizen
+        - caseworker-cmc
+        - caseworker-cmc-solicitor
+        - caseworker-cmc-systemupdate
+        - letter-holder
+        - caseworker-autotest1
+```
+
 The idam secret and s2s keys need to be loaded in the pipeline,
 example config:
 
@@ -100,6 +138,27 @@ If you need to change from the defaults consider sending a PR to the chart inste
 
 | Parameter                  | Description                                | Default  |
 | -------------------------- | ------------------------------------------ | ----- |
+| `appInsightsKey`                | Application insights key for full CCD stack | `fake-key`|
+| `memoryRequests`           | Requests for memory | `512Mi`|
+| `cpuRequests`              | Requests for cpu | `100m`|
+| `memoryLimits`             | Memory limits| `1024Mi`|
+| `cpuLimits`                | CPU limits | `2500m`|
+| `ingressHost`              | Host for ingress controller to map the container to | `nil` (required, provided by the pipeline)  |
+| `ingressIP`              | Ingress controllers IP address | `nil` (required, provided by the pipeline)  |
+| `consulIP`              | Consul servers IP address | `nil` (required, provided by the pipeline) |
+| `readinessPath`            | Path of HTTP readiness probe | `/health`|
+| `readinessDelay`           | Readiness probe inital delay (seconds)| `30`|
+| `readinessTimeout`         | Readiness probe timeout (seconds)| `3`|
+| `readinessPeriod`          | Readiness probe period (seconds) | `15`|
+| `livenessPath`             | Path of HTTP liveness probe | `/health`|
+| `livenessDelay`            | Liveness probe inital delay (seconds)  | `30`|
+| `livenessTimeout`          | Liveness probe timeout (seconds) | `3`|
+| `livenessPeriod`           | Liveness probe period (seconds) | `15`|
+| `livenessFailureThreshold` | Liveness failure threshold | `3` |
+| `s2sUrl`                | S2S api url | `http://rpe-service-auth-provider-aat.service.core-compute-aat.internal`|
+| `idamWebUrl`                | Idam web url | `https://idam.preprod.ccidam.reform.hmcts.net`|
+| `idamApiUrl`                | Idam api url | `https://preprod-idamapi.reform.hmcts.net:3511`|
+| `paymentsUrl`                | Payments api url | `http://payment-api-aat.service.core-compute-aat.internal`|
 | `userProfileApi.image`          | User profile api's image version | `hmcts.azurecr.io/hmcts/ccd-user-profile-api:latest`|
 | `userProfileApi.applicationPort`                    | Port user profile api runs on | `4453` |
 | `userProfileApi.authorisedServices`              |  A list of services allowed to contact user profile api | `ccd_data,ccd_definition,ccd_admin`|
@@ -128,27 +187,31 @@ If you need to change from the defaults consider sending a PR to the chart inste
 | `printApi.applicationPort`                    | Port definition case print service runs on | `3100` |
 | `printApi.s2sKey`                    | S2S key | `nil` (required must be set by user) |
 | `printApi.probateTemplateUrl`        | Probate callback url | `nil` (required must be set by user) |
-| `s2sUrl`                | S2S api url | `http://rpe-service-auth-provider-aat.service.core-compute-aat.internal`|
-| `idamWebUrl`                | Idam web url | `https://idam.preprod.ccidam.reform.hmcts.net`|
-| `idamApiUrl`                | Idam api url | `https://preprod-idamapi.reform.hmcts.net:3511`|
-| `paymentsUrl`                | Payments api url | `http://payment-api-aat.service.core-compute-aat.internal`|
-| `appInsightsKey`                | Application insights key for full CCD stack | `fake-key`|
-| `memoryRequests`           | Requests for memory | `512Mi`|
-| `cpuRequests`              | Requests for cpu | `100m`|
-| `memoryLimits`             | Memory limits| `1024Mi`|
-| `cpuLimits`                | CPU limits | `2500m`|
-| `ingressHost`              | Host for ingress controller to map the container to | `nil` (required, provided by the pipeline)  |
-| `ingressIP`              | Ingress controllers IP address | `nil` (required, provided by the pipeline)  |
-| `consulIP`              | Consul servers IP address | `nil` (required, provided by the pipeline) |
-| `readinessPath`            | Path of HTTP readiness probe | `/health`|
-| `readinessDelay`           | Readiness probe inital delay (seconds)| `30`|
-| `readinessTimeout`         | Readiness probe timeout (seconds)| `3`|
-| `readinessPeriod`          | Readiness probe period (seconds) | `15`|
-| `livenessPath`             | Path of HTTP liveness probe | `/health`|
-| `livenessDelay`            | Liveness probe inital delay (seconds)  | `30`|
-| `livenessTimeout`          | Liveness probe timeout (seconds) | `3`|
-| `livenessPeriod`           | Liveness probe period (seconds) | `15`|
-| `livenessFailureThreshold` | Liveness failure threshold | `3` |
+| `importer.definition.enabled` | Enabling Definition importer | `false` |
+| `importer.definition.image` | Definition importer image to use | `hmcts/ccd-definition-importer:latest` |
+
+| `importer.definition.kvSecretRef` | Secret with credentials for accessing necessary key vaults in Azure | `kvcreds` |
+| `importer.definition.gitSecretRef` | Secret with gitlab credentials for accessing defined defintions, if using gitlab urls | `kvcreds` |
+| `importer.definition.definitions` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`CCD_DEF_URLS` | `nil` |
+| `importer.definition.definitionFilename` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`CCD_DEF_FILENAME` | `nil` |
+| `importer.definition.waitHosts` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`WAIT_HOSTS` | `nil` |
+| `importer.definition.waitHostsTimeout` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`WAIT_HOSTS_TIMEOUT` | `300` |
+| `importer.definition.userRoles` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`USER_ROLES` | `- caseworker-bulkscan` |
+| `importer.definition.microservice` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`MICROSERVICE` | `ccd_gw` |
+| `importer.definition.verbose` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`VERBOSE` | `false` |
+| `importer.userprofile.enabled` | Enabling User Profile importer | `false` |
+| `importer.userprofile.image` | User Profile importer image to use | `hmcts.azurecr.io/hmcts/ccd-user-profile-importer:latest` |
+| `importer.userprofile.users` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USERS` | `nil` |
+| `importer.userprofile.jurisdictions` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_JURISDICTIONS` | `nil` |
+| `importer.userprofile.microservice` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`MICROSSERVICE` | `ccd_definition` |
+| `importer.userprofile.waitHosts` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`WAIT_HOSTS` | `nil` |
+| `importer.userprofile.waitHostsTimeout` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`WAIT_HOSTS_TIMEOUT` | `300` |
+| `importer.userprofile.userProfileDatabaseHost` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USER_PROFILE_DB_HOST` | `nil` |
+| `importer.userprofile.userProfileDatabasePort` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USER_PROFILE_DB_PORT` | `nil` |
+| `importer.userprofile.userProfileDatabaseUser` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USER_PROFILE_DB_USERNAME` | `nil` |
+| `importer.userprofile.userProfileDatabasePassword` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USER_PROFILE_DB_PASSWORD` | `nil` |
+| `importer.userprofile.userProfileDatabaseName` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USER_PROFILE_DB_DATABASE` | `nil` |
+| `importer.userprofile.verbose` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`VERBOSE` | `false` |
 
 ## Development and Testing
 

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 0.7.0
+version: 1.0.0
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 0.6.2
+version: 0.7.0
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/templates/_helpers.tpl
+++ b/ccd/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "importer.vault" }}
+{{- define "importer.definition.vault" }}
   {{- if eq .Values.global.subscriptionId "bf308a5c-0624-4334-8ff8-8dca9fd43783"}}
   {{- "ccd-saat" -}}
   {{- else }}
@@ -6,7 +6,7 @@
   {{- end }}
 {{- end }}
 
-{{- define "importer.resourcegroup" }}
+{{- define "importer.definition.resourcegroup" }}
   {{- if eq .Values.global.subscriptionId "bf308a5c-0624-4334-8ff8-8dca9fd43783"}}
   {{- "ccd-shared-saat" -}}
   {{- else }}
@@ -14,7 +14,7 @@
   {{- end }}
 {{- end }}
 
-{{- define "importer.vaultGit" }}
+{{- define "importer.definition.vaultGit" }}
   {{- if eq .Values.global.subscriptionId "bf308a5c-0624-4334-8ff8-8dca9fd43783"}}
   {{- "infra-vault-sandbox" -}}
   {{- else }}
@@ -22,7 +22,7 @@
   {{- end }}
 {{- end }}
 
-{{- define "importer.redirect" }}
+{{- define "importer.definition.redirect" }}
   {{- if eq .Values.global.subscriptionId "bf308a5c-0624-4334-8ff8-8dca9fd43783"}}
   {{- "https://ccd-case-management-web-saat-staging.service.core-compute-saat.internal/oauth2redirect" -}}
   {{- else }}

--- a/ccd/templates/definition-importer.yaml
+++ b/ccd/templates/definition-importer.yaml
@@ -100,5 +100,5 @@ spec:
             limits:
               memory: {{ .Values.memoryLimits }}
               cpu: {{ .Values.cpuLimits }}
-      restartPolicy: Never   # Move to "OnFailure" after first charts are done 
+      restartPolicy: Never
 {{- end }}

--- a/ccd/templates/definition-importer.yaml
+++ b/ccd/templates/definition-importer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.importer.definitions }}
+{{- if .Values.importer.definition.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -26,31 +26,31 @@ spec:
           flexVolume:
             driver: "azure/kv"
             secretRef:
-              name: {{ default "kvcreds" .Values.importer.kvSecretRef }} 
+              name: {{ default "kvcreds" .Values.importer.definition.kvSecretRef }} 
             options:
               usepodidentity: "false"
               subscriptionid: {{ .Values.global.subscriptionId }}
               tenantid: {{ .Values.global.tenantId }}
-              keyvaultname: {{ include "importer.vault" . | quote }}
-              resourcegroup: {{ include "importer.resourcegroup" . | quote }}
+              keyvaultname: {{ include "importer.definition.vault" . | quote }}
+              resourcegroup: {{ include "importer.definition.resourcegroup" . | quote }}
               keyvaultobjectnames: "ccd-as-a-pr-importer-username;ccd-as-a-pr-importer-password"
               keyvaultobjecttypes: "secret;secret" # OPTIONS: secret, key, cert
         - name: gitcreds
           flexVolume:
             driver: "azure/kv"
             secretRef:
-              name: {{ default "kvcreds" .Values.importer.gitSecretRef }} 
+              name: {{ default "kvcreds" .Values.importer.definition.gitSecretRef }} 
             options:
               usepodidentity: "false"
               subscriptionid: {{ .Values.global.subscriptionId }}
               tenantid: {{ .Values.global.tenantId }}
-              keyvaultname: {{ include "importer.vaultGit" . | quote }}
+              keyvaultname: {{ include "importer.definition.vaultGit" . | quote }}
               resourcegroup: "cnp-core-infra"
               keyvaultobjectnames: "hmcts-github-apikey"
               keyvaultobjecttypes: "secret" # OPTIONS: secret, key, cert
       containers:
         - name: {{ .Release.Name }}-definition-importer
-          image: {{ .Values.importer.image }} 
+          image: {{ .Values.importer.definition.image }} 
           volumeMounts:
           - name: kvcreds
             mountPath: /kvmnt
@@ -60,13 +60,13 @@ spec:
             readOnly: true
           env:
           - name: CCD_DEF_URLS
-            value: {{ join "," .Values.importer.definitions | quote }}
+            value: {{ join "," .Values.importer.definition.definitions | quote }}
           - name: CCD_DEF_FILENAME
-            value: {{ .Values.importer.definitionFilename | quote }}
+            value: {{ .Values.importer.definition.definitionFilename | quote }}
           - name: WAIT_HOSTS
-            value: {{ .Values.importer.waitHosts | quote }}
+            value: {{ .Values.importer.definition.waitHosts | quote }}
           - name: WAIT_HOSTS_TIMEOUT
-            value: {{ .Values.importer.waitHostsTimeout | quote }}
+            value: {{ .Values.importer.definition.waitHostsTimeout | quote }}
           - name: CREATE_IMPORTER_USER
             value: "false"
           - name: IMPORTER_CREDS_MOUNT
@@ -76,23 +76,23 @@ spec:
           - name: IDAM_URI
             value: {{ .Values.idamApiUrl }}
           - name: REDIRECT_URI  
-            value: {{ include "importer.redirect" . | quote }}
+            value: {{ include "importer.definition.redirect" . | quote }}
           - name: CLIENT_ID
             value: "ccd_gateway"
           - name: CLIENT_SECRET
             value: {{ .Values.apiGateway.idamClientSecret | quote }}
           - name: USER_ROLES
-            value: {{ join "," .Values.importer.userRoles }}
+            value: {{ join "," .Values.importer.definition.userRoles }}
           - name: MICROSERVICE_BASE_URL
             value: http://{{ required "A valid ingressHost is required." .Values.ingressHost }}
           - name: AUTH_PROVIDER_BASE_URL
             value: {{ .Values.s2sUrl }}
           - name: MICROSERVICE
-            value: {{ .Values.importer.microservice }}
+            value: {{ .Values.importer.definition.microservice }}
           - name: CCD_STORE_BASE_URL
             value: http://{{ .Release.Name }}-definition-store-api
           - name: VERBOSE
-            value: {{ .Values.importer.verbose | quote }}
+            value: {{ .Values.importer.definition.verbose | quote }}
           resources:
             requests:
               memory: {{ .Values.memoryRequests }}

--- a/ccd/templates/user-profile-importer.yaml
+++ b/ccd/templates/user-profile-importer.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.importer.userprofile.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-user-profile-importer"
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-user-profile-importer"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation  # Move to hook-succeeded after first charts are done 
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-user-profile-importer"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      containers:
+        - name: {{ .Release.Name }}-user-profile-importer
+          image: {{ .Values.importer.userprofile.image }} 
+          env:
+          - name: CCD_USER_PROFILE_URL
+            value: http://{{ .Release.Name }}-user-profile-api
+          - name: AUTH_PROVIDER_BASE_URL
+            value: {{ .Values.s2sUrl }}
+          - name: MICROSERVICE
+            value: {{ .Values.importer.userprofile.microservice }}
+          - name: CCD_USERS
+            value: {{ join "," .Values.importer.userprofile.users | quote }}
+          - name: WAIT_HOSTS
+            value: {{ .Values.importer.userprofile.waitHosts | quote }}
+          - name: WAIT_HOSTS_TIMEOUT
+            value: {{ .Values.importer.userprofile.waitHostsTimeout | quote }}
+          - name: CCD_USER_PROFILE_DB_HOST
+            value: {{ .Values.importer.userprofile.userProfileDatabaseHost | quote }}
+          - name: CCD_USER_PROFILE_DB_PORT
+            value: {{ .Values.importer.userprofile.userProfileDatabasePort | quote }}
+          - name: CCD_USER_PROFILE_DB_USERNAME
+            value: {{ .Values.importer.userprofile.userProfileDatabaseUser | quote }}
+          - name: CCD_USER_PROFILE_DB_PASSWORD
+            value: {{ .Values.importer.userprofile.userProfileDatabasePassword | quote }}
+          - name: CCD_USER_PROFILE_DB_DATABASE
+            value: {{ .Values.importer.userprofile.userProfileDatabaseName | quote }}
+          - name: JURISDICTION
+            value: {{ .Values.importer.userprofile.jurisdiction | quote }}
+          - name: DEFAULT_CASE_TYPE
+            value: {{ .Values.importer.userprofile.defaultCaseType | quote }}
+          - name: DEFAULT_CASE_STATE
+            value: {{ .Values.importer.userprofile.defaultCaseState | quote }}
+          - name: VERBOSE
+            value: {{ .Values.importer.userprofile.verbose | quote }}
+          resources:
+            requests:
+              memory: {{ .Values.memoryRequests }}
+              cpu: {{ .Values.cpuRequests }}
+            limits:
+              memory: {{ .Values.memoryLimits }}
+              cpu: {{ .Values.cpuLimits }}
+      restartPolicy: Never   # Move to "OnFailure" after first charts are done 
+{{- end }}

--- a/ccd/templates/user-profile-importer.yaml
+++ b/ccd/templates/user-profile-importer.yaml
@@ -58,5 +58,4 @@ spec:
             limits:
               memory: {{ .Values.memoryLimits }}
               cpu: {{ .Values.cpuLimits }}
-      restartPolicy: Never   # Move to "OnFailure" after first charts are done 
 {{- end }}

--- a/ccd/templates/user-profile-importer.yaml
+++ b/ccd/templates/user-profile-importer.yaml
@@ -58,4 +58,5 @@ spec:
             limits:
               memory: {{ .Values.memoryLimits }}
               cpu: {{ .Values.cpuLimits }}
+      restartPolicy: Never
 {{- end }}

--- a/ccd/templates/user-profile-importer.yaml
+++ b/ccd/templates/user-profile-importer.yaml
@@ -33,6 +33,8 @@ spec:
             value: {{ .Values.importer.userprofile.microservice }}
           - name: CCD_USERS
             value: {{ join "," .Values.importer.userprofile.users | quote }}
+          - name: CCD_JURISDICTIONS
+            value: {{ join "," .Values.importer.userprofile.jurisdictions | quote }}
           - name: WAIT_HOSTS
             value: {{ .Values.importer.userprofile.waitHosts | quote }}
           - name: WAIT_HOSTS_TIMEOUT
@@ -47,12 +49,6 @@ spec:
             value: {{ .Values.importer.userprofile.userProfileDatabasePassword | quote }}
           - name: CCD_USER_PROFILE_DB_DATABASE
             value: {{ .Values.importer.userprofile.userProfileDatabaseName | quote }}
-          - name: JURISDICTION
-            value: {{ .Values.importer.userprofile.jurisdiction | quote }}
-          - name: DEFAULT_CASE_TYPE
-            value: {{ .Values.importer.userprofile.defaultCaseType | quote }}
-          - name: DEFAULT_CASE_STATE
-            value: {{ .Values.importer.userprofile.defaultCaseState | quote }}
           - name: VERBOSE
             value: {{ .Values.importer.userprofile.verbose | quote }}
           resources:

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -70,17 +70,39 @@ postgresql:
     enabled: false
 
 importer:
-  image: hmcts/ccd-definition-importer:latest
-  kvSecretRef: kvcreds
-  gitSecretRef: kvcreds
-  # Definitions is a list. For example:
-  # definitions:
-  # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test_Exception_Record.template.xlsx
-  # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test.template.xlsx
-  definitions:
-  waitHosts: ""
-  waitHostsTimeout: 300
-  userRoles:
-    - caseworker-bulkscan
-  microservice: ccd_gw
-  verbose: "false"
+  userprofile:
+    enabled: false
+    image: hmcts.azurecr.io/hmcts/ccd-user-profile-importer:latest
+    # Users is a list of IDAM emails. For example:
+    # users:
+    # - me@example.com
+    # - you@example.com
+    users: 
+    waitHosts: ""
+    waitHostsTimeout: 300
+    microservice: ccd_definition
+    verbose: "false"
+    jurisdiction: ""
+    defaultCaseType: ""
+    defaultCaseState: ""
+    userProfileDatabaseHost: ""
+    userProfileDatabasePort: ""
+    userProfileDatabaseUser: ""
+    userProfileDatabasePassword: ""
+    userProfileDatabaseName: ""
+  definition:
+    enabled: false
+    image: hmcts/ccd-definition-importer:latest
+    kvSecretRef: kvcreds
+    gitSecretRef: kvcreds
+    # Definitions is a list. For example:
+    # definitions:
+    # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test_Exception_Record.template.xlsx
+    # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test.template.xlsx
+    definitions:
+    waitHosts: ""
+    waitHostsTimeout: 300
+    userRoles:
+      - caseworker-bulkscan
+    microservice: ccd_gw
+    verbose: "false"

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -73,18 +73,20 @@ importer:
   userprofile:
     enabled: false
     image: hmcts.azurecr.io/hmcts/ccd-user-profile-importer:latest
-    # Users is a list of IDAM emails. For example:
+    # Users is a list of delimted strings in format: idamEmail|ccdJurisdiction|ccdDefaultCaseType|ccdDefaultCaseState. For example:
     # users:
-    # - me@example.com
-    # - you@example.com
+    # - mryan321.hmcts.claimant+1@gmail.com|CMC|MoneyClaimCase|open
+    # - mryan321.hmcts.claimant+2@gmail.com|SSCS|SSCS|open
     users: 
+    # Jurisdictions is a list of jurisdictions referenced in above users. For example:
+    # jurisdictions:
+    # - CMC
+    # - SSCS
+    jurisdictions:
     waitHosts: ""
     waitHostsTimeout: 300
     microservice: ccd_definition
     verbose: "false"
-    jurisdiction: ""
-    defaultCaseType: ""
-    defaultCaseState: ""
     userProfileDatabaseHost: ""
     userProfileDatabasePort: ""
     userProfileDatabaseUser: ""
@@ -100,6 +102,7 @@ importer:
     # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test_Exception_Record.template.xlsx
     # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test.template.xlsx
     definitions:
+    definitionFilename: ""
     waitHosts: ""
     waitHostsTimeout: 300
     userRoles:

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -2,8 +2,8 @@ ingressHost: chart-ccd-release.service.core-compute-preview.internal
 ingressIP: "10.97.17.51"
 consulIP: "10.97.11.254"
 
-readinessDelay: 120
-livenessDelay: 120
+readinessDelay: 90
+livenessDelay: 90
 
 apiGateway:
   s2sKey: "AAAAAAAAAAAAAAAA"


### PR DESCRIPTION
### Change description ###

Decouple definitions and user-profile importing. Based on: https://github.com/hmcts/ccd-docker-user-profile-importer

Tested locally: 
Helm: `cmc-ccd-helm-testing                    1               Thu Mar 21 21:00:18 2019        DEPLOYED        cmc-claim-store-0.1.0                                   money-claims`
K8S: `kubectl get po | grep helm-testing`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
