### PR TITLE
Handle whitelisting with idam-pr chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ An example url for accessing case management web would be:
 https://case-management-web-sscs-cor-backend-pr-189.service.core-compute-preview.internal/
 ```
 
+### IDAM whitelisting for web components
+
+Manged using https://github.com/hmcts/chart-idam-pr.
+
+To enable add following to your values.preview.template.yaml:
+```
+tags:
+  case-mgmt-web-idam-pr: true
+  admin-web-idam-pr: true
+
+ccd:
+  # other ccd config
+
+  case-mgmt-web-idam-pr:
+    releaseNameOverride: ${SERVICE_NAME}-ccd-www-idam-pr
+    service:
+      name: CCD
+      redirect_uri: https://admin-web-${SERVICE_FQDN}/oauth2redirect
+  admin-web-idam-pr:
+    releaseNameOverride: ${SERVICE_NAME}-ccd-admin-idam-pr
+    service:
+      name: CCD Admin
+      redirect_uri: https://case-management-web-${SERVICE_FQDN}/oauth2redirect
+```
+
 ## Configuration
 
 The following table lists the configurable parameters of the CCD chart and their default values.

--- a/README.md
+++ b/README.md
@@ -132,27 +132,23 @@ https://case-management-web-sscs-cor-backend-pr-189.service.core-compute-preview
 
 ### IDAM whitelisting for web components
 
-Manged using https://github.com/hmcts/chart-idam-pr.
+Managed using https://github.com/hmcts/chart-idam-pr (version 2.0.0 and above).
 
 To enable add following to your values.preview.template.yaml:
 ```
 tags:
-  case-mgmt-web-idam-pr: true
-  admin-web-idam-pr: true
+  ccd-idam-pr: true
 
 ccd:
   # other ccd config
 
-  case-mgmt-web-idam-pr:
-    releaseNameOverride: ${SERVICE_NAME}-ccd-www-idam-pr
-    service:
-      name: CCD
-      redirect_uri: https://admin-web-${SERVICE_FQDN}/oauth2redirect
-  admin-web-idam-pr:
-    releaseNameOverride: ${SERVICE_NAME}-ccd-admin-idam-pr
-    service:
-      name: CCD Admin
-      redirect_uri: https://case-management-web-${SERVICE_FQDN}/oauth2redirect
+  idam-pr:
+    releaseNameOverride: ${SERVICE_NAME}-ccd-idam-pr
+    redirect_uris:
+      CCD:
+        - https://case-management-web-${SERVICE_FQDN}/oauth2redirect
+      CCD Admin:
+        - https://admin-web-${SERVICE_FQDN}/oauth2redirect
 ```
 
 ## Configuration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
       chartName: ccd
       chartReleaseName: chart-ccd-ci-test
       chartNamespace: chart-tests
-      helmInstallTimeout: "300"
+      helmInstallTimeout: "600"
 
 - job: Release
   # Make sure we have a tag to run this job

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 1.0.0
+version: 1.1.0
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/requirements.yaml
+++ b/ccd/requirements.yaml
@@ -4,3 +4,18 @@ dependencies:
     repository: '@stable'
     tags:
       - postgresql-pod
+  - name: idam-pr
+    alias: case-mgmt-web-idam-pr
+    version: ~1.0.0
+#    repository: '@hmcts'
+    repository: file:///Users/markry/workspace/hmcts/chart-idam-pr/idam-pr
+    tags:
+      - case-mgmt-web-idam-pr
+  - name: idam-pr
+    alias: admin-web-idam-pr
+    version: ~1.0.0
+#    repository: '@hmcts'
+    repository: file:///Users/markry/workspace/hmcts/chart-idam-pr/idam-pr
+    tags:
+      - admin-web-idam-pr
+

--- a/ccd/requirements.yaml
+++ b/ccd/requirements.yaml
@@ -5,17 +5,8 @@ dependencies:
     tags:
       - postgresql-pod
   - name: idam-pr
-    alias: case-mgmt-web-idam-pr
-    version: ~1.0.0
-#    repository: '@hmcts'
-    repository: file:///Users/markry/workspace/hmcts/chart-idam-pr/idam-pr
+    version: ~2.0.0
+    repository: '@hmcts'
     tags:
-      - case-mgmt-web-idam-pr
-  - name: idam-pr
-    alias: admin-web-idam-pr
-    version: ~1.0.0
-#    repository: '@hmcts'
-    repository: file:///Users/markry/workspace/hmcts/chart-idam-pr/idam-pr
-    tags:
-      - admin-web-idam-pr
+      - ccd-idam-pr
 

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -1,5 +1,7 @@
 tags:
   postgresql-pod: true
+  case-mgmt-web-idam-pr: false
+  admin-web-idam-pr: false
   
 userProfileApi:
   image: hmcts.azurecr.io/hmcts/ccd-user-profile-api:latest

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -1,7 +1,6 @@
 tags:
   postgresql-pod: true
-  case-mgmt-web-idam-pr: false
-  admin-web-idam-pr: false
+  ccd-idam-pr: false
   
 userProfileApi:
   image: hmcts.azurecr.io/hmcts/ccd-user-profile-api:latest


### PR DESCRIPTION
### Change description ###

SIDAM requires exact URLs to be whitelisted. A chart was introduced to help - it will add/remove per PR.

This change adds a whitelisting requirement for both web UI components - disabled by default. To be overridden in values.preview.template.yaml:

```
tags:
  ccd-idam-pr: true

ccd:
  idam-pr:
    releaseNameOverride: cmc-ccd-test-ccd-www-idam-pr
    redirect_uris:
      CCD:
      - https://case-management-web-cmc-ccd-test.service.core-compute-preview.internal/oauth2redirect
     CCD Admin: 
     - https://admin-web-cmc-ccd-test.service.core-compute-preview.internal/oauth2redirect
```

Tested with `cmc-ccd-test` Helm release on cnp-aks-cluster.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
