### PR TITLE
Various tweaks for HMCTS Demo preparation with CMC stack

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 1.1.2
+version: 2.0.0
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 1.1.1
+version: 1.1.2
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 1.1.0
+version: 1.1.1
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/templates/_helpers.tpl
+++ b/ccd/templates/_helpers.tpl
@@ -21,11 +21,3 @@
   {{- "infra-vault-nonprod" -}}
   {{- end }}
 {{- end }}
-
-{{- define "importer.definition.redirect" }}
-  {{- if eq .Values.global.subscriptionId "bf308a5c-0624-4334-8ff8-8dca9fd43783"}}
-  {{- "https://ccd-case-management-web-saat-staging.service.core-compute-saat.internal/oauth2redirect" -}}
-  {{- else }}
-  {{- "https://ccd-case-management-web-preview.service.core-compute-preview.internal/oauth2redirect" -}}
-  {{- end }}
-{{- end }}

--- a/ccd/templates/admin-web.yaml
+++ b/ccd/templates/admin-web.yaml
@@ -83,7 +83,7 @@ spec:
         - name: IDAM_ADMIN_WEB_SERVICE_KEY
           value: {{ required "`adminWeb.s2sKey` must be set in your values.yaml file" .Values.adminWeb.s2sKey }}
         - name: IDAM_OAUTH2_AW_CLIENT_SECRET
-          value: {{ required "`adminWeb.idamClientSecret` must be set in your values.yaml file" .Values.adminWeb.idamClientSecret }}
+          value: {{ required "`adminWeb.idamClientSecret` must be set in your values.yaml file" .Values.adminWeb.idamClientSecret | quote }}
         {{- if .Values.adminWeb.environment }}
           {{- range $key, $val := .Values.adminWeb.environment }}
         - name: {{ $key }}

--- a/ccd/templates/admin-web.yaml
+++ b/ccd/templates/admin-web.yaml
@@ -66,6 +66,10 @@ spec:
           value: https://user-profile-api-{{ .Values.ingressHost }}/users/save
         - name: ADMINWEB_USER_PROFILE_URL
           value: https://user-profile-api-{{ .Values.ingressHost }}/users
+        - name: ADMINWEB_DELETE_DEFINITION_URL
+          value: http://definition-store-api-{{ .Values.ingressHost }}/api/draft
+        - name: ADMINWEB_ROLES_WHITELIST
+          value: 'ccd-import,ccd-import-validate'
         - name: ADMINWEB_LOGIN_URL
           value: {{ .Values.idamWebUrl }}/login
         - name: IDAM_LOGOUT_URL

--- a/ccd/templates/bin-configmap.yaml
+++ b/ccd/templates/bin-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.consulIP ) (.Values.ingressIP) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,3 +11,4 @@ metadata:
 data:
   ccd-dns: |
 {{ include (print .Template.BasePath "/bin/_dns-register.tpl") . | indent 4 }}
+{{- end -}}

--- a/ccd/templates/bin/_dns-register.tpl
+++ b/ccd/templates/bin/_dns-register.tpl
@@ -7,6 +7,6 @@ for service in $@
 do
   echo "Registering service: ${service}"
   curl -X PUT -H 'Content-Type: application/json' \
-    -d "{\"Name\":\"${service}\",\"Service\":\"${service}\",\"Address\":\"{{ required "`ingressIP` must be set in your values.yaml file" .Values.ingressIP }}\",\"Port\":80}" \
-    http://{{ required "`consulIP` must be set in your values.yaml file" .Values.consulIP }}:8500/v1/agent/service/register
+    -d "{\"Name\":\"${service}\",\"Service\":\"${service}\",\"Address\":\"{{ .Values.ingressIP }}\",\"Port\":80}" \
+    http://{{ .Values.consulIP }}:8500/v1/agent/service/register
 done

--- a/ccd/templates/data-store-api.yaml
+++ b/ccd/templates/data-store-api.yaml
@@ -22,7 +22,7 @@ spec:
         name: {{ .Release.Name }}-data-store-api
         env:
         - name: DATA_STORE_DB_HOST
-          value: {{ .Release.Name }}-ccd-postgres
+          value: {{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}
         - name: DATA_STORE_DB_PORT
           value: '5432'
         - name: DATA_STORE_DB_NAME

--- a/ccd/templates/definition-importer.yaml
+++ b/ccd/templates/definition-importer.yaml
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      {{- if .Values.importer.definition.kvSecretRef }}
       volumes:
         - name: kvcreds
           flexVolume:
@@ -48,9 +49,12 @@ spec:
               resourcegroup: "cnp-core-infra"
               keyvaultobjectnames: "hmcts-github-apikey"
               keyvaultobjecttypes: "secret" # OPTIONS: secret, key, cert
+      {{- end }}
       containers:
         - name: {{ .Release.Name }}-definition-importer
           image: {{ .Values.importer.definition.image }} 
+          imagePullPolicy: IfNotPresent
+          {{- if .Values.importer.definition.kvSecretRef }}
           volumeMounts:
           - name: kvcreds
             mountPath: /kvmnt
@@ -58,6 +62,7 @@ spec:
           - name: gitcreds
             mountPath: /gitmnt
             readOnly: true
+          {{- end }}
           env:
           - name: CCD_DEF_URLS
             value: {{ join "," .Values.importer.definition.definitions | quote }}
@@ -69,14 +74,16 @@ spec:
             value: {{ .Values.importer.definition.waitHostsTimeout | quote }}
           - name: CREATE_IMPORTER_USER
             value: "false"
+          {{- if .Values.importer.definition.kvSecretRef }}
           - name: IMPORTER_CREDS_MOUNT
             value: "/kvmnt"
           - name: GITHUB_CREDS_MOUNT
             value: "/gitmnt"
+          {{- end }}
           - name: IDAM_URI
             value: {{ .Values.idamApiUrl }}
           - name: REDIRECT_URI  
-            value: {{ include "importer.definition.redirect" . | quote }}
+            value: {{ .Values.importer.definition.redirectUri | quote }}
           - name: CLIENT_ID
             value: "ccd_gateway"
           - name: CLIENT_SECRET
@@ -93,6 +100,10 @@ spec:
             value: http://{{ .Release.Name }}-definition-store-api
           - name: VERBOSE
             value: {{ .Values.importer.definition.verbose | quote }}
+          - name: IMPORTER_USERNAME
+            value: {{ .Values.importer.definition.importerUsername | quote }}  # kvcreds takes priority
+          - name: IMPORTER_PASSWORD
+            value: {{ .Values.importer.definition.importerPassword | quote }}  # kvcreds takes priority
           resources:
             requests:
               memory: {{ .Values.memoryRequests }}

--- a/ccd/templates/definition-store-api.yaml
+++ b/ccd/templates/definition-store-api.yaml
@@ -30,7 +30,7 @@ spec:
         - name: APPINSIGHTS_INSTRUMENTATIONKEY
           value: {{ .Values.appInsightsKey }}
         - name: DEFINITION_STORE_DB_HOST
-          value: {{ .Release.Name }}-ccd-postgres
+          value: {{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}
         - name: DEFINITION_STORE_DB_PORT
           value: '5432'
         - name: DEFINITION_STORE_DB_NAME

--- a/ccd/templates/dns.yaml
+++ b/ccd/templates/dns.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.consulIP ) (.Values.ingressIP) -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -54,3 +55,4 @@ spec:
               memory: {{ .Values.memoryLimits }}
               cpu: {{ .Values.cpuLimits }}
       restartPolicy: Never
+{{- end -}}

--- a/ccd/templates/user-profile-api.yaml
+++ b/ccd/templates/user-profile-api.yaml
@@ -28,7 +28,7 @@ spec:
         - name: APPINSIGHTS_INSTRUMENTATIONKEY
           value: {{ .Values.appInsightsKey }}
         - name: USER_PROFILE_DB_HOST
-          value: {{ .Release.Name }}-ccd-postgres
+          value: {{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}
         - name: USER_PROFILE_DB_PORT
           value: '5432'
         - name: USER_PROFILE_DB_NAME

--- a/ccd/templates/user-profile-importer.yaml
+++ b/ccd/templates/user-profile-importer.yaml
@@ -24,6 +24,7 @@ spec:
       containers:
         - name: {{ .Release.Name }}-user-profile-importer
           image: {{ .Values.importer.userprofile.image }} 
+          imagePullPolicy: IfNotPresent
           env:
           - name: CCD_USER_PROFILE_URL
             value: http://{{ .Release.Name }}-user-profile-api

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -36,10 +36,10 @@ printApi:
   image: hmcts.azurecr.io/hmcts/ccd-case-print-service:latest
   applicationPort: 3100
 
+idamApiUrl: https://idam-api.aat.platform.hmcts.net
+idamWebUrl: https://idam-web-public.aat.platform.hmcts.net
 s2sUrl: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
 draftStoreUrl: "http://draft-store-service-aat.service.core-compute-aat.internal"
-idamWebUrl: "https://idam.preprod.ccidam.reform.hmcts.net"
-idamApiUrl: "https://preprod-idamapi.reform.hmcts.net:3511"
 paymentsUrl: "http://payment-api-aat.service.core-compute-aat.internal"
 appInsightsKey: "fake-key"
 

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -96,8 +96,8 @@ importer:
   definition:
     enabled: false
     image: hmcts/ccd-definition-importer:latest
-    kvSecretRef: kvcreds
-    gitSecretRef: kvcreds
+    # kvSecretRef: kvcreds
+    # gitSecretRef: kvcreds
     # Definitions is a list. For example:
     # definitions:
     # - https://github.com/hmcts/chart-ccd/raw/master/data/CCD_Definition_Test_Exception_Record.template.xlsx
@@ -110,3 +110,4 @@ importer:
       - caseworker-bulkscan
     microservice: ccd_gw
     verbose: "false"
+    redirectUri: "https://ccd-case-management-web-aat.service.core-compute-aat.internal/oauth2redirect"


### PR DESCRIPTION
### Change description ###

Fixes:

- postgres nameOverride hardcoded in manifests
- remove requirement for consol & ingress IPs
- adminWeb IDAM secret to use quotes (breaks if use value like 12345678)
- removed default: `kvSecretRef: kvcreds` value
- changed redirect url to a value

Tested locally.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes (bumped major version because it won't mount kvcreds by default now)
[ ] No
```
