### PR TITLE
Option to use env vars from secrets or value

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 2.0.0
+version: 3.0.0
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/templates/admin-web.yaml
+++ b/ccd/templates/admin-web.yaml
@@ -22,6 +22,16 @@ spec:
       - image: {{ .Values.adminWeb.image }}
         name: {{ .Release.Name }}-admin-web
         env:
+        {{- if .Values.adminWeb.idamClientSecret.fromSecret }}
+        - name: IDAM_OAUTH2_AW_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.adminWeb.idamClientSecret.secretKeyRefName | quote }}
+              key: {{ .Values.adminWeb.idamClientSecret.secretKeyRefKey | quote }}
+        {{- else }}
+        - name: IDAM_OAUTH2_AW_CLIENT_SECRET
+          value: {{ .Values.adminWeb.idamClientSecret.value | quote }}
+        {{- end }}
         - name: IDAM_OAUTH2_CLIENT_ID
           value: ccd_admin
         - name: HPKP_MAX_AGE
@@ -82,8 +92,6 @@ spec:
           value: {{ .Values.s2sUrl }}
         - name: IDAM_ADMIN_WEB_SERVICE_KEY
           value: {{ required "`adminWeb.s2sKey` must be set in your values.yaml file" .Values.adminWeb.s2sKey }}
-        - name: IDAM_OAUTH2_AW_CLIENT_SECRET
-          value: {{ required "`adminWeb.idamClientSecret` must be set in your values.yaml file" .Values.adminWeb.idamClientSecret | quote }}
         {{- if .Values.adminWeb.environment }}
           {{- range $key, $val := .Values.adminWeb.environment }}
         - name: {{ $key }}

--- a/ccd/templates/api-gateway.yaml
+++ b/ccd/templates/api-gateway.yaml
@@ -22,6 +22,16 @@ spec:
       - image: {{ .Values.apiGateway.image }}
         name: {{ .Release.Name }}-api-gateway
         env:
+        {{- if .Values.apiGateway.idamClientSecret.fromSecret }}
+        - name: IDAM_OAUTH2_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiGateway.idamClientSecret.secretKeyRefName | quote }}
+              key: {{ .Values.apiGateway.idamClientSecret.secretKeyRefKey | quote }}
+        {{- else }}
+        - name: IDAM_OAUTH2_CLIENT_SECRET
+          value: {{ .Values.apiGateway.idamClientSecret.value | quote }}
+        {{- end }} 
         - name: APPINSIGHTS_INSTRUMENTATIONKEY
           value: {{ .Values.appInsightsKey }}
         - name: IDAM_BASE_URL
@@ -32,8 +42,6 @@ spec:
           value: {{ .Values.idamApiUrl }}/session/:token
         - name: IDAM_OAUTH2_CLIENT_ID
           value: 'ccd_gateway'
-        - name: IDAM_OAUTH2_CLIENT_SECRET
-          value: {{ .Values.apiGateway.idamClientSecret | quote }}
         # S2S
         - name: IDAM_S2S_URL
           value: {{ .Values.s2sUrl }}

--- a/ccd/templates/definition-importer.yaml
+++ b/ccd/templates/definition-importer.yaml
@@ -79,6 +79,27 @@ spec:
             value: "/kvmnt"
           - name: GITHUB_CREDS_MOUNT
             value: "/gitmnt"
+          {{- else }}
+            {{- if .Values.importer.definition.importerFromSecret }}
+          - name: IMPORTER_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.importer.definition.importerUsername.secretKeyRefName | quote }}
+                key: {{ .Values.importer.definition.importerUsername.secretKeyRefKey | quote }}
+            {{- else }}
+          - name: IMPORTER_USERNAME
+            value: {{.Values.importer.definition.importerUsername.value | quote }}
+            {{- end }} 
+            {{- if .Values.importer.definition.importerFromSecret }}
+          - name: IMPORTER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.importer.definition.importerPassword.secretKeyRefName | quote }}
+                key: {{ .Values.importer.definition.importerPassword.secretKeyRefKey | quote }}
+            {{- else }}
+          - name: IMPORTER_PASSWORD
+            value: {{.Values.importer.definition.importerPassword.value | quote }}
+            {{- end }} 
           {{- end }}
           - name: IDAM_URI
             value: {{ .Values.idamApiUrl }}
@@ -86,8 +107,16 @@ spec:
             value: {{ .Values.importer.definition.redirectUri | quote }}
           - name: CLIENT_ID
             value: "ccd_gateway"
+          {{- if .Values.apiGateway.idamClientSecret.fromSecret }}
           - name: CLIENT_SECRET
-            value: {{ .Values.apiGateway.idamClientSecret | quote }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.apiGateway.idamClientSecret.secretKeyRefName | quote }}
+                key: {{ .Values.apiGateway.idamClientSecret.secretKeyRefKey | quote }}
+          {{- else }}
+          - name: CLIENT_SECRET
+            value: {{ .Values.apiGateway.idamClientSecret.value | quote }}
+          {{- end }} 
           - name: USER_ROLES
             value: {{ join "," .Values.importer.definition.userRoles }}
           - name: MICROSERVICE_BASE_URL
@@ -100,10 +129,6 @@ spec:
             value: http://{{ .Release.Name }}-definition-store-api
           - name: VERBOSE
             value: {{ .Values.importer.definition.verbose | quote }}
-          - name: IMPORTER_USERNAME
-            value: {{ .Values.importer.definition.importerUsername | quote }}  # kvcreds takes priority
-          - name: IMPORTER_PASSWORD
-            value: {{ .Values.importer.definition.importerPassword | quote }}  # kvcreds takes priority
           resources:
             requests:
               memory: {{ .Values.memoryRequests }}

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -7,7 +7,8 @@ livenessDelay: 90
 
 apiGateway:
   s2sKey: "AAAAAAAAAAAAAAAA"
-  idamClientSecret: "123456"
+  idamClientSecret:
+    value: "123456"
 
 dataStoreApi:
   s2sKey: "AAAAAAAAAAAAAAAA"


### PR DESCRIPTION

### Change description ###

Breaking change - idam secret definition changes.

Allows to use value or a secret to define idam tokens.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - bumped to 3.0.0
[ ] No
```
