### PR TITLE
Allow Env Vars for templates in Def Importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.tgz
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ If you need to change from the defaults consider sending a PR to the chart inste
 | `importer.definition.userRoles` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`USER_ROLES` | `- caseworker-bulkscan` |
 | `importer.definition.microservice` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`MICROSERVICE` | `ccd_gw` |
 | `importer.definition.verbose` | https://github.com/hmcts/ccd-docker-definition-importer#configuration : parameter:`VERBOSE` | `false` |
+| `importer.definition.environment` | Helpful for templating defintions if using base image: https://github.com/hmcts/ccd-definition-processor | `null` |
 | `importer.userprofile.enabled` | Enabling User Profile importer | `false` |
 | `importer.userprofile.image` | User Profile importer image to use | `hmcts.azurecr.io/hmcts/ccd-user-profile-importer:latest` |
 | `importer.userprofile.users` | https://github.com/hmcts/ccd-docker-user-profile-importer#configuration : parameter=`CCD_USERS` | `nil` |

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 3.0.4
+version: 3.0.5
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 3.0.6
+version: 3.0.7
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product
 name: ccd
-version: 3.0.5
+version: 3.0.6
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/requirements.lock
+++ b/ccd/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 2.6.6
-digest: sha256:1c7adebe72ed1b9a582b4697a4614de2ce08f4cf835b6d320592dff7207436b2
-generated: 2018-11-30T12:18:07.328155Z

--- a/ccd/templates/case-management-web.yaml
+++ b/ccd/templates/case-management-web.yaml
@@ -37,7 +37,7 @@ spec:
         - name: CCD_GW_OAUTH2_CLIENT_ID
           value: ccd_gateway
         - name: DM_URL
-          value: https://gateway-{{ .Values.ingressHost }}/oauth2
+          value: https://gateway-{{ .Values.ingressHost }}/documents
        # - name: DM_URL_REMOTE TODO look at this
        #   value: 'false'
         - name: CCD_PAGE_SIZE

--- a/ccd/templates/definition-importer.yaml
+++ b/ccd/templates/definition-importer.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "5"
-    helm.sh/hook-delete-policy: before-hook-creation  # Move to hook-succeeded after first charts are done 
+    helm.sh/hook-delete-policy: before-hook-creation  # Move to hook-succeeded after first charts are done
 spec:
   template:
     metadata:
@@ -27,7 +27,7 @@ spec:
           flexVolume:
             driver: "azure/kv"
             secretRef:
-              name: {{ default "kvcreds" .Values.importer.definition.kvSecretRef }} 
+              name: {{ default "kvcreds" .Values.importer.definition.kvSecretRef }}
             options:
               usepodidentity: "false"
               subscriptionid: {{ .Values.global.subscriptionId }}
@@ -40,7 +40,7 @@ spec:
           flexVolume:
             driver: "azure/kv"
             secretRef:
-              name: {{ default "kvcreds" .Values.importer.definition.gitSecretRef }} 
+              name: {{ default "kvcreds" .Values.importer.definition.gitSecretRef }}
             options:
               usepodidentity: "false"
               subscriptionid: {{ .Values.global.subscriptionId }}
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-definition-importer
-          image: {{ .Values.importer.definition.image }} 
+          image: {{ .Values.importer.definition.image }}
           imagePullPolicy: IfNotPresent
           {{- if .Values.importer.definition.kvSecretRef }}
           volumeMounts:
@@ -89,7 +89,7 @@ spec:
             {{- else }}
           - name: IMPORTER_USERNAME
             value: {{.Values.importer.definition.importerUsername.value | quote }}
-            {{- end }} 
+            {{- end }}
             {{- if .Values.importer.definition.importerFromSecret }}
           - name: IMPORTER_PASSWORD
             valueFrom:
@@ -99,11 +99,11 @@ spec:
             {{- else }}
           - name: IMPORTER_PASSWORD
             value: {{.Values.importer.definition.importerPassword.value | quote }}
-            {{- end }} 
+            {{- end }}
           {{- end }}
           - name: IDAM_URI
             value: {{ .Values.idamApiUrl }}
-          - name: REDIRECT_URI  
+          - name: REDIRECT_URI
             value: {{ .Values.importer.definition.redirectUri | quote }}
           - name: CLIENT_ID
             value: "ccd_gateway"
@@ -116,7 +116,7 @@ spec:
           {{- else }}
           - name: CLIENT_SECRET
             value: {{ .Values.apiGateway.idamClientSecret.value | quote }}
-          {{- end }} 
+          {{- end }}
           - name: USER_ROLES
             value: {{ join "," .Values.importer.definition.userRoles }}
           - name: MICROSERVICE_BASE_URL
@@ -129,6 +129,12 @@ spec:
             value: http://{{ .Release.Name }}-definition-store-api
           - name: VERBOSE
             value: {{ .Values.importer.definition.verbose | quote }}
+          {{- if .Values.importer.definition.environment }}
+            {{- range $key, $val := .Values.importer.definition.environment }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+            {{- end}}
+          {{- end }}
           resources:
             requests:
               memory: {{ .Values.memoryRequests }}

--- a/ccd/templates/ingress-api-gateway.yaml
+++ b/ccd/templates/ingress-api-gateway.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.caseManagementWeb.enabled }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ccd-api-gateway
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-ccd-api-gateway
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}-ccd-api-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}-ccd-api-gateway
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.apiGateway.ingressClass }}
+spec:
+  rules:
+  - host: gateway-{{ .Values.ingressHost }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-api-gateway
+          servicePort: 80
+{{- end }}

--- a/ccd/templates/ingress.yaml
+++ b/ccd/templates/ingress.yaml
@@ -27,13 +27,6 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}-case-management-web
           servicePort: 80
-  - host: gateway-{{ .Values.ingressHost }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ .Release.Name }}-api-gateway
-          servicePort: 80
   {{- end }}
   {{- if .Values.adminWeb.enabled }}
   - host: admin-web-{{ .Values.ingressHost }}

--- a/ccd/values.yaml
+++ b/ccd/values.yaml
@@ -30,6 +30,7 @@ adminWeb:
 apiGateway:
   image: hmctspublic.azurecr.io/ccd/api-gateway-web:latest
   applicationPort: 3453
+  ingressClass: "traefik"
 
 printApi:
   enabled: false


### PR DESCRIPTION
This applies the same changes to 3.0.6 as was applied by 3.1.1 to 3.1.0 to allow environment variables to be used to replaced templated values. Mark Ryan's previous commit is https://github.com/hmcts/chart-ccd/commit/c3f843b4c04933018484d62a140dccff89c246d7