### PR TITLE
Upgrading rpe-service-auth-provider

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CCD product.
 name: ccd
-version: 4.2.2
+version: 4.2.3
 icon: https://github.com/hmcts/chart-ccd/raw/master/images/icons8-java-50.png
 keywords:
   - ccd

--- a/ccd/requirements.yaml
+++ b/ccd/requirements.yaml
@@ -5,7 +5,7 @@ dependencies:
     condition: ccd.postgresql.enabled
 
   - name: rpe-service-auth-provider
-    version: ~0.2.3
+    version: ~2.15.0
     repository: '@hmctspublic'
     condition: ccd.s2s.enabled
 


### PR DESCRIPTION
### Change description ###
We're getting errors when using this version of CCD charts.
Example: https://build-beta.platform.hmcts.net/job/HMCTS_FinRem/job/finrem-ccd-definitions/job/PR-66/5/console

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
