### PR TITLE
Bump chart version for es with new ingress

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -91,7 +91,7 @@ dependencies:
     condition: ccd.emAnnotation.enabled
 
   - name: elasticsearch
-    version: 7.8.1
+    version: 7.8.2
     repository: '@hmctspublic'
     condition: ccd.elastic.enabled
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-9530

### Change description ###

We have had to patch ingress on elasticsearch chart for our cluster upgrades due to deprecated API version that would break builds. Going forward we will want to update whole chart

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
