### PR TITLE
upgrade am chart - currently causing broken builds on preview

### DIFF
--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -96,7 +96,7 @@ dependencies:
     condition: ccd.elastic.enabled
 
   - name: am-role-assignment-service
-    version: 0.0.62
+    version: 0.0.74
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.ras.enabled
   


### PR DESCRIPTION
Current Errors on Preview: MountVolume.SetUp failed for volume "vault-am"

As am pods are still trying to use managed identity, but should have been moved to Workload Identity a few months ago.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
