### PR TITLE
WIP // DO NOT MERGE // v8.0.30+ Java Helm Chart dependency upgrades v3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,45 +2,45 @@ name: chart-ccd pipeline
 trigger:
   branches:
     include:
-    - refs/tags/*
+      - refs/tags/*
 pr:
   branches:
     include:
-    - master
+      - master
 resources:
   repositories:
-  - repository: cnp-library
-    type: github
-    ref: master
-    name: hmcts/cnp-azuredevops-libraries
-    endpoint: 'hmcts'
+    - repository: cnp-azuredevops-libraries
+      type: github
+      ref: master
+      name: hmcts/cnp-azuredevops-libraries
+      endpoint: 'hmcts'
 
 jobs:
-- job: Validate
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - template: steps/charts/validate.yaml@cnp-library
-    parameters:
-      chartName: ccd
-      chartReleaseName: chart-ccd-ci-test
-      chartNamespace: chart-tests
-      helmInstallTimeout: "1000"
+  - job: Validate
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - template: steps/charts/validate.yaml@cnp-azuredevops-libraries
+        parameters:
+          chartName: ccd
+          chartReleaseName: chart-ccd-ci-test
+          chartNamespace: chart-tests
+          helmInstallTimeout: "1000"
 
 
-- job: Release
-  # Make sure we have a tag to run this job
-  condition: >
-    and(
-        succeeded(),
-        startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-      )
-  dependsOn: Validate
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - template: steps/charts/release.yaml@cnp-library
-    parameters:
-      chartName: ccd
-      chartReleaseName: chart-ccd
-      chartNamespace: chart-tests
+  - job: Release
+    # Make sure we have a tag to run this job
+    condition: >
+      and(
+          succeeded(),
+          startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+        )
+    dependsOn: Validate
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - template: steps/charts/release.yaml@cnp-azuredevops-libraries
+        parameters:
+          chartName: ccd
+          chartReleaseName: chart-ccd
+          chartNamespace: chart-tests

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -46,12 +46,12 @@ dependencies:
     condition: ccd.adminWeb.enabled
 
   - name: draft-store-service
-    version: 2.1.1
+    version: 2.2.4
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.draftStore.enabled
 
   - name: dm-store
-    version: 2.1.39
+    version: 2.2.21
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.dmStore.enabled
 
@@ -86,7 +86,7 @@ dependencies:
     condition: ccd.blobstorage.enabled
 
   - name: em-anno
-    version: 1.0.17
+    version: 1.0.18
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.emAnnotation.enabled
 
@@ -101,7 +101,7 @@ dependencies:
     condition: ccd.elastic.enabled
 
   - name: am-role-assignment-service
-    version: 0.0.77
+    version: 0.0.78
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.ras.enabled
 

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     condition: ccd.definitionStore.enabled
 
   - name: ccd-data-store-api
-    version: 2.0.26
+    version: 2.0.27
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.dataStore.enabled
 

--- a/ccd/Chart.yaml
+++ b/ccd/Chart.yaml
@@ -16,32 +16,32 @@ dependencies:
     condition: ccd.postgresql.enabled
 
   - name: rpe-service-auth-provider
-    version: 0.3.85
+    version: 0.3.109
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.s2s.enabled
 
   - name: ccd-user-profile-api
-    version: 1.6.10
+    version: 1.6.14
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.userProfile.enabled
 
   - name: ccd-definition-store-api
-    version: 1.6.14
+    version: 1.6.17
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.definitionStore.enabled
 
   - name: ccd-data-store-api
-    version: 2.0.20
+    version: 2.0.26
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.dataStore.enabled
 
   - name: ccd-api-gateway-web
-    version: 1.2.5
+    version: 1.2.7
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.apiGatewayWeb.enabled
 
   - name: ccd-admin-web
-    version: 2.2.6
+    version: 2.2.8
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.adminWeb.enabled
 
@@ -56,17 +56,17 @@ dependencies:
     condition: ccd.dmStore.enabled
 
   - name: ccd-case-print-service
-    version: 1.3.5
+    version: 1.3.7
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.printService.enabled
 
   - name: ccd-case-activity-api
-    version: 1.3.7
+    version: 1.3.9
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.activityApi.enabled
 
   - name: ccd-test-stubs-service
-    version: 1.2.10
+    version: 1.2.12
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.testStubsService.enabled
 
@@ -101,11 +101,11 @@ dependencies:
     condition: ccd.elastic.enabled
 
   - name: am-role-assignment-service
-    version: 0.0.62
+    version: 0.0.77
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.ras.enabled
-  
+
   - name: ccd-message-publisher
-    version: 0.1.11
+    version: 0.1.16
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd.mps.enabled


### PR DESCRIPTION
### Change description ###
Experimental v8.0.30+ Java Helm Chart dependency upgrades

v8-chart-upgrades branch now contains v8.0.30 only, as a stand-in for master. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes - not compatible with v9+
[ ] No
```
